### PR TITLE
fix: incorrect reviewer linkedin link

### DIFF
--- a/content/blogs/2024-09-26-low-carbon-dans-le-cloud-partie-1/index.md
+++ b/content/blogs/2024-09-26-low-carbon-dans-le-cloud-partie-1/index.md
@@ -17,7 +17,7 @@ reviewers:
   - id: 67adfd77-4b84-4496-b55d-3391541f59c5
     name: Michaël Bernasinski
     image: https://prod-files-secure.s3.us-west-2.amazonaws.com/5863e833-64f2-4f13-9f7a-2c92c72b5bbf/82ebd0fe-de28-43f3-ab7b-0431af41baad/Photo_HoppR.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45HZZMZUHI%2F20240926%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20240926T191302Z&X-Amz-Expires=3600&X-Amz-Signature=ceadc4bf7580a016b5ac0b1159488b990250b831bccf0691e4ae7bf3f87eacff&X-Amz-SignedHeaders=host&x-id=GetObject
-    linkedin: www.linkedin.com/in/michael-bernasinski
+    linkedin: https://www.linkedin.com/in/michael-bernasinski
     x: 
   - id: 0bb914a6-f882-4951-bee6-53e8e8abb807
     name: Emmanuelle Gouvart

--- a/content/blogs/2024-09-26-low-carbon-dans-le-cloud-partie-2/index.md
+++ b/content/blogs/2024-09-26-low-carbon-dans-le-cloud-partie-2/index.md
@@ -17,7 +17,7 @@ reviewers:
   - id: 67adfd77-4b84-4496-b55d-3391541f59c5
     name: Michaël Bernasinski
     image: https://prod-files-secure.s3.us-west-2.amazonaws.com/5863e833-64f2-4f13-9f7a-2c92c72b5bbf/82ebd0fe-de28-43f3-ab7b-0431af41baad/Photo_HoppR.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAT73L2G45HZZMZUHI%2F20240926%2Fus-west-2%2Fs3%2Faws4_request&X-Amz-Date=20240926T191417Z&X-Amz-Expires=3600&X-Amz-Signature=9a6ac271ef20e015de8631306a9a3d9ee599b8bd6515bc6660813db235ccc1f1&X-Amz-SignedHeaders=host&x-id=GetObject
-    linkedin: www.linkedin.com/in/michael-bernasinski
+    linkedin: https://www.linkedin.com/in/michael-bernasinski
     x: 
   - id: 45c76823-ab7d-4c1f-84b3-0bad16ab91e1
     name: Paul-Alexandre Chrétien


### PR DESCRIPTION
Le lien de mon LinkedIn était **www.linkedin.com/in/michael-bernasinski** et non **https://www.linkedin.com/in/michael-bernasinski** sur Notion.

Du coup, le lien est cassé sur certains articles dont je fais partie des reviewers. Exemple :
- KO : https://blog.hoppr.tech/blogs/2024-09-26-low-carbon-dans-le-cloud-partie-2
- OK : https://blog.hoppr.tech/blogs/2024-09-27-sauvegarder-ltat-final-dun-agrgat-par-ses-vnements (j'ai changé ma fiche sur Notion entre-temps)

J'ai corrigé à la main directement sur les articles dans cette PR.
Cela dit, je ne sais pas s'il est normal que ce soit mal interprété et que le lien sans le **https://** donne un lien du type https://blog.hoppr.tech/blogs/www.linkedin.com/in/michael-bernasinski
Je préférais que tu sois au courant au cas où @mderoullers 