### PR TITLE
fix: blog toc height scrolls #48

### DIFF
--- a/components/blog/Toc.vue
+++ b/components/blog/Toc.vue
@@ -27,7 +27,7 @@ const isExpanded = (id: string) => expandedSections.value.has(id)
 </script>
 
 <template>
-  <div class="lg:col-span-3 sticky top-28 mt-5 h-96 hidden lg:block justify-self-end w-full">
+  <div class="lg:col-span-3 sticky top-28 mt-5 h-auto hidden lg:block justify-self-end w-full">
     <div class="border dark:border-zinc-500 p-4 rounded-md w-[250px] max-w-[350px] dark:bg-slate-900 shadow-md">
       <h2 class="text-lg font-bold mb-4 border-b dark:border-zinc-500 pb-2 text-hoppr-green">
         Table des matières

--- a/components/blog/Toc/Toc.vue
+++ b/components/blog/Toc/Toc.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useDisplayActiveSection } from './composables/useDisplayActiveSection'
+
+useDisplayActiveSection()
 
 const { path } = useRoute()
 const articles = await queryContent(path).findOne()
@@ -24,53 +27,6 @@ function toggleSection(id: string) {
 }
 
 const isExpanded = (id: string) => expandedSections.value.has(id)
-
-const currentSection = ref<null | string>(null);
-let observer: IntersectionObserver
-
-onMounted(() => {
-  observer = new IntersectionObserver((entries) => {
-    entries.forEach((entry) => {
-      if (entry.isIntersecting) {
-        const sectionHref = entry.target.querySelector('a')?.getAttribute('href')
-        if (sectionHref) {
-
-          currentSection.value = sectionHref
-
-          // Update the TOC to highlight the corresponding link
-          updateToc(sectionHref)
-        }
-      }
-    })
-  }, { threshold: 1.0 })
-
-  // Observe the article sections
-  document.querySelectorAll('.article-section h2, .article-section h3, .article-section h4').forEach((section) => {
-    observer.observe(section)
-  })
-})
-
-onUnmounted(() => {
-  observer.disconnect()
-})
-
-function updateToc(sectionHref: string) {
-  const tocLinks = document.querySelectorAll('#toc-content a');
-  const currentLinkEndsWithSectionHref = ({ sectionHref, linkHref }: { sectionHref: string, linkHref: string }): boolean => {
-    const regex = new RegExp(`^.*${sectionHref}$`);
-    return regex.test(linkHref!)
-
-  }
-  tocLinks.forEach((link) => {
-    link.classList.remove('active')
-    const linkHref = link.getAttribute('href')
-
-    if (linkHref && currentLinkEndsWithSectionHref({ linkHref, sectionHref })) {
-      link.classList.add('active')
-    }
-  })
-}
-
 </script>
 
 <template>

--- a/components/blog/Toc/composables/useDisplayActiveSection.ts
+++ b/components/blog/Toc/composables/useDisplayActiveSection.ts
@@ -1,0 +1,49 @@
+import { onMounted, onUnmounted, ref } from 'vue';
+
+export function useDisplayActiveSection() {
+  const currentSection = ref<null | string>(null);
+  let observer: IntersectionObserver;
+
+  onMounted(() => {
+    observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const sectionHref = entry.target.querySelector('a')?.getAttribute('href')
+          if (sectionHref) {
+
+            currentSection.value = sectionHref
+
+            // Update the TOC to highlight the corresponding link
+            updateToc(sectionHref)
+          }
+        }
+      })
+    }, { threshold: 1.0 })
+
+    // Observe the article sections
+    document.querySelectorAll('.article-section h2, .article-section h3, .article-section h4').forEach((section) => {
+      observer.observe(section)
+    })
+  })
+
+  onUnmounted(() => {
+    observer.disconnect()
+  })
+
+  function updateToc(sectionHref: string) {
+    const tocLinks = document.querySelectorAll('#toc-content a');
+    const currentLinkEndsWithSectionHref = ({ sectionHref, linkHref }: { sectionHref: string, linkHref: string }): boolean => {
+      const regex = new RegExp(`^.*${sectionHref}$`);
+      return regex.test(linkHref!)
+
+    }
+    tocLinks.forEach((link) => {
+      link.classList.remove('active')
+      const linkHref = link.getAttribute('href')
+
+      if (linkHref && currentLinkEndsWithSectionHref({ linkHref, sectionHref })) {
+        link.classList.add('active')
+      }
+    })
+  }
+}

--- a/pages/blogs/[blog].vue
+++ b/pages/blogs/[blog].vue
@@ -146,7 +146,7 @@ defineOgImageComponent('About', {
             prose-h2:border-l-4 prose-h2:border-hoppr-green prose-h2:pl-2
             prose-h3:italic"
         >
-          <ContentRenderer v-if="article" :value="article">
+          <ContentRenderer v-if="article" :value="article" class="article-section">
             <template #empty>
               <p>No content found.</p>
             </template>


### PR DESCRIPTION
Fixes #48 

TOC content can now scroll with the content

Here's a demo of the behavior allowed by the fix:
![screenshot-2024-12-12-16h14m08s](https://github.com/user-attachments/assets/470ba43b-34c7-4054-8153-873e69cf1205)

Imo it's a quicker fix than handling the toggling of `<h2>` `<h3>`. Let me know if it does not suit the intended behavior.