### PR TITLE
fix(publish): reject tags containing an apostrophe before publication

### DIFF
--- a/server/services/github/postChecker.test.ts
+++ b/server/services/github/postChecker.test.ts
@@ -52,6 +52,22 @@ describe('postChecker', () => {
     })
   })
 
+  describe('check tags', () => {
+    it('should throw Error when a tag contains an apostrophe', () => {
+      const post = buildDefaultPost()
+      post.tags = ['événement', '2026', 'agi\'lille', 'rex']
+      expect(() => checkPost(post)).toThrowError(
+        'Tag "agi\'lille" contains an apostrophe (\'), which breaks the article frontmatter. Rename the tag in Notion before publishing.',
+      )
+    })
+
+    it('should not throw Error for tags without apostrophe', () => {
+      const post = buildDefaultPost()
+      post.tags = ['événement', '2026', 'agilille', 'rex']
+      expect(() => checkPost(post)).not.toThrowError()
+    })
+  })
+
   describe('check blocks', () => {
     const paragraphBlock = buildDefaultParagraphBlock()
     const heading1Block = buildDefaultHeading1Block()

--- a/server/services/github/postChecker.ts
+++ b/server/services/github/postChecker.ts
@@ -5,6 +5,7 @@ export function checkPost(post: BlogPost) {
   checkImage(post.image)
   checkDate(post.date)
   checkContent(post.content)
+  checkTags(post.tags)
 }
 
 function checkImage(image: string) {
@@ -23,6 +24,14 @@ function checkDate(date: string) {
 function checkContent(content: string) {
   if (!content)
     throw new Error('Content is missing')
+}
+
+// Tags are serialized as single-quoted YAML scalars in the frontmatter: an
+// apostrophe inside a tag closes the scalar early and breaks the whole build.
+function checkTags(tags: string[]) {
+  const invalidTag = tags.find(tag => tag.includes('\''))
+  if (invalidTag)
+    throw new Error(`Tag "${invalidTag}" contains an apostrophe ('), which breaks the article frontmatter. Rename the tag in Notion before publishing.`)
 }
 
 export function checkBlocks(blocks: BlockObjectResponse[]) {


### PR DESCRIPTION
## Problème

L'article #139 (`Pitcher son produit…`) a été publié avec le tag `agi'lille`. Les tags sont sérialisés en scalaires YAML single-quoted dans le frontmatter :

```yaml
tags: ['événement', '2026', 'agi'lille', 'rex', 'others']
```

L'apostrophe ferme le scalaire prématurément → YAML invalide → `nuxt build` échoue avec une erreur cryptique (`did not find expected ',' or ']' while parsing a flow sequence`).

## Solution

Ajout d'une règle dans `checkPost` (`postChecker.ts`), la validation qui tourne avant la génération du markdown dans le pipeline de publication Notion → GitHub :

- Si un tag contient une apostrophe, la publication échoue immédiatement avec un message explicite : `Tag "agi'lille" contains an apostrophe ('), which breaks the article frontmatter. Rename the tag in Notion before publishing.`
- La PR d'article n'est jamais créée/mergée, et le statut Notion n'est pas passé à « Publié » (le `finally` de `githubService` nettoie la branche).

## Tests

- `should throw Error when a tag contains an apostrophe` (RED d'abord, puis GREEN)
- `should not throw Error for tags without apostrophe`
- `bun test server/services/github/` : 22 pass sur les modules touchés (l'échec de `pullRequestManager.test.ts` est préexistant, `useRuntimeConfig` non défini hors env Nuxt)

## Hors scope

- L'article déjà mergé sur `main` contient toujours le tag invalide : à renommer côté Notion et republier (ou corriger le frontmatter à la main).