### PR TITLE
fix(seo): resolve page metadata and pagination SEO issues

### DIFF
--- a/components/category/card.vue
+++ b/components/category/card.vue
@@ -2,11 +2,11 @@
 import { Icon } from '#components'
 
 interface Props {
-  title: string
+  title?: string
   value: string
-  count: number
-  index: number
-  totalTags: number
+  count?: number
+  index?: number
+  totalTags?: number
   icon: string
   colors: {
     light: string
@@ -20,31 +20,36 @@ const props = withDefaults(defineProps<Props>(), {
   index: 0,
   totalTags: 1,
 })
-
-const colorMode = useColorMode()
-
-const getCategoryColor = computed(() => {
-  return colorMode.value === 'dark' ? props.colors.dark : props.colors.light
-})
 </script>
 
 <template>
-  <ClientOnly>
-    <div
-      class="px-5 py-3 rounded hover:scale-110 transition-all duration-300"
-      :style="{ backgroundColor: getCategoryColor }"
+  <div
+    class="category-card px-5 py-3 rounded hover:scale-110 transition-all duration-300"
+    :style="{
+      '--category-color-light': props.colors.light,
+      '--category-color-dark': props.colors.dark,
+    }"
+  >
+    <NuxtLink
+      :to="`/categories/${props.value}`"
+      class="text-lg font-extrabold tracking-wider flex items-center text-white dark:text-hoppr-black"
     >
-      <NuxtLink :to="`/categories/${props.value}`" class="text-lg font-extrabold tracking-wider flex items-center">
-        <Icon
-          :name="props.icon"
-          size="24"
-          class="mr-2"
-          :class="{ 'text-white': colorMode.value === 'light', 'text-hoppr-black': colorMode.value === 'dark' }"
-        />
-        <h1 :class="{ 'text-white': colorMode.value === 'light', 'text-hoppr-black': colorMode.value === 'dark' }">
-          {{ title }} ({{ count }})
-        </h1>
-      </NuxtLink>
-    </div>
-  </ClientOnly>
+      <Icon
+        :name="props.icon"
+        size="24"
+        class="mr-2"
+      />
+      <span>{{ title }} ({{ count }})</span>
+    </NuxtLink>
+  </div>
 </template>
+
+<style scoped>
+.category-card {
+  background-color: var(--category-color-light);
+}
+
+:global(.dark) .category-card {
+  background-color: var(--category-color-dark);
+}
+</style>

--- a/components/tag/card.vue
+++ b/components/tag/card.vue
@@ -1,9 +1,9 @@
 <script setup lang="ts">
 interface Props {
-  title: string
-  count: number
-  index: number
-  totalTags: number
+  title?: string
+  count?: number
+  index?: number
+  totalTags?: number
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -44,28 +44,30 @@ const colors = {
   ],
 }
 
-const colorMode = useColorMode()
-
-const picAColor = computed(() => {
-  const currentColors = colorMode.value === 'dark' ? colors.dark : colors.light
-  return currentColors[props.index % currentColors.length]
-})
+const lightColor = computed(() => colors.light[props.index % colors.light.length])
+const darkColor = computed(() => colors.dark[props.index % colors.dark.length])
 </script>
 
 <template>
-  <ClientOnly>
-    <div class="px-5 py-3 rounded rand-bg-color hover:scale-110 transition-all duration-300">
-      <NuxtLink :to="`/tags/${title.toLocaleLowerCase()}`" class="text-lg font-extrabold tracking-wider">
-        <h1 :class="{ 'text-white': colorMode.value === 'light', 'text-hoppr-black': colorMode.value === 'dark' }">
-          #{{ title }} ({{ count }})
-        </h1>
-      </NuxtLink>
-    </div>
-  </ClientOnly>
+  <div
+    class="px-5 py-3 rounded rand-bg-color hover:scale-110 transition-all duration-300"
+    :style="{ '--tag-color-light': lightColor, '--tag-color-dark': darkColor }"
+  >
+    <NuxtLink
+      :to="`/tags/${title.toLocaleLowerCase()}`"
+      class="text-lg font-extrabold tracking-wider text-white dark:text-hoppr-black"
+    >
+      <span>#{{ title }} ({{ count }})</span>
+    </NuxtLink>
+  </div>
 </template>
 
 <style scoped>
 .rand-bg-color {
-  background-color: v-bind(picAColor);
+  background-color: var(--tag-color-light);
+}
+
+:global(.dark) .rand-bg-color {
+  background-color: var(--tag-color-dark);
 }
 </style>

--- a/components/ui/Pagination.vue
+++ b/components/ui/Pagination.vue
@@ -1,13 +1,17 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref } from 'vue'
+import { buildPaginationUrl } from '@/utils/pagination'
 
 interface Props {
   currentPage: number
   totalPages: number
   baseUrl: string
+  query?: Record<string, string>
 }
 
-const props = defineProps<Props>()
+const props = withDefaults(defineProps<Props>(), {
+  query: () => ({}),
+})
 const emit = defineEmits<{
   (e: 'pageChange', page: number): void
 }>()
@@ -46,9 +50,7 @@ const pageRange = computed(() => {
 })
 
 function pageUrl(page: number): string {
-  if (page === 1)
-    return props.baseUrl
-  return `${props.baseUrl}?page=${page}`
+  return buildPaginationUrl(props.baseUrl, page, props.query)
 }
 
 function goToPage(page: number) {

--- a/composables/usePageSeo.test.ts
+++ b/composables/usePageSeo.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { ref } from 'vue'
 import { getLastHeadCall, setupSeoMocks } from '@/tests/seo/test-helpers'
 
 const { mockUseHead } = setupSeoMocks()
@@ -165,5 +166,25 @@ describe('usePageSeo', () => {
     const call = getLastHeadCall(mockUseHead)
     const robots = call.meta.find((m: { name?: string }) => m.name === 'robots')
     expect(robots).toBeUndefined()
+  })
+
+  it('should react to canonical and robots changes', () => {
+    const url = ref('/blogs')
+    const noindex = ref(false)
+
+    usePageSeo({
+      title: 'Test',
+      description: 'Desc',
+      url,
+      noindex,
+    })
+
+    url.value = '/blogs?page=2'
+    noindex.value = true
+
+    const call = getLastHeadCall(mockUseHead)
+    expect(call.link[0]?.href).toBe('https://blog.hoppr.tech/blogs?page=2')
+    expect(call.meta.find((meta: { name?: string }) => meta.name === 'robots')?.content)
+      .toBe('noindex, follow')
   })
 })

--- a/composables/usePageSeo.ts
+++ b/composables/usePageSeo.ts
@@ -1,17 +1,29 @@
+import type { MaybeRefOrGetter } from 'vue'
 import type { JsonLdNode } from '@/utils/organization'
+import { toValue } from 'vue'
 import { useAbsoluteUrl } from './useAbsoluteUrl'
 
+const TRAILING_SLASH = /\/$/
+
 interface SeoMetaOptions {
-  title: string
-  description: string
-  url: string
-  image?: string
-  type?: string
-  publishedTime?: string
-  modifiedTime?: string
-  authors?: string[]
-  jsonLd?: JsonLdNode | JsonLdNode[]
-  noindex?: boolean
+  title: MaybeRefOrGetter<string>
+  description: MaybeRefOrGetter<string>
+  url: MaybeRefOrGetter<string>
+  image?: MaybeRefOrGetter<string | undefined>
+  type?: MaybeRefOrGetter<string | undefined>
+  publishedTime?: MaybeRefOrGetter<string | undefined>
+  modifiedTime?: MaybeRefOrGetter<string | undefined>
+  authors?: MaybeRefOrGetter<string[] | undefined>
+  jsonLd?: MaybeRefOrGetter<JsonLdNode | JsonLdNode[] | undefined>
+  noindex?: MaybeRefOrGetter<boolean | undefined>
+}
+
+function resolveAbsoluteUrl(path: string, baseUrl: string): string {
+  if (path.startsWith('http://') || path.startsWith('https://'))
+    return path
+
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${baseUrl}${normalizedPath}`
 }
 
 /**
@@ -19,76 +31,79 @@ interface SeoMetaOptions {
  * Ensures absolute URLs, consistent og:site_name, og:locale, and no og:image conflicts.
  */
 export function usePageSeo(options: SeoMetaOptions): void {
-  const {
-    title,
-    description,
-    url,
-    image,
-    type = 'website',
-    publishedTime,
-    modifiedTime,
-    authors,
-    jsonLd,
-    noindex,
-  } = options
+  // Resolve Nuxt runtime state while the composable is executing. The reactive
+  // head factory can also run later during Nitro prerendering, outside an active
+  // Nuxt instance, so it must only use plain values and reactive inputs.
+  const baseUrl = useAbsoluteUrl('/').replace(TRAILING_SLASH, '')
 
-  const absoluteUrl = useAbsoluteUrl(url)
-  const absoluteImage = image ? useAbsoluteUrl(image) : undefined
+  useHead(() => {
+    const title = toValue(options.title)
+    const description = toValue(options.description)
+    const absoluteUrl = resolveAbsoluteUrl(toValue(options.url), baseUrl)
+    const image = toValue(options.image)
+    const absoluteImage = image ? resolveAbsoluteUrl(image, baseUrl) : undefined
+    const type = toValue(options.type) || 'website'
+    const publishedTime = toValue(options.publishedTime)
+    const modifiedTime = toValue(options.modifiedTime)
+    const authors = toValue(options.authors)
+    const jsonLd = toValue(options.jsonLd)
+    const noindex = toValue(options.noindex)
 
-  const meta: Array<{ name?: string, property?: string, content: string }> = [
-    { name: 'description', content: description },
-    { property: 'og:site_name', content: 'Blog HoppR' },
-    { property: 'og:locale', content: 'fr_FR' },
-    { property: 'og:type', content: type },
-    { property: 'og:url', content: absoluteUrl },
-    { property: 'og:title', content: title },
-    { property: 'og:description', content: description },
-    { name: 'twitter:card', content: 'summary_large_image' },
-    { name: 'twitter:url', content: absoluteUrl },
-    { name: 'twitter:title', content: title },
-    { name: 'twitter:description', content: description },
-  ]
+    const meta: Array<{ name?: string, property?: string, content: string }> = [
+      { name: 'description', content: description },
+      { property: 'og:site_name', content: 'Blog HoppR' },
+      { property: 'og:locale', content: 'fr_FR' },
+      { property: 'og:type', content: type },
+      { property: 'og:url', content: absoluteUrl },
+      { property: 'og:title', content: title },
+      { property: 'og:description', content: description },
+      { name: 'twitter:card', content: 'summary_large_image' },
+      { name: 'twitter:url', content: absoluteUrl },
+      { name: 'twitter:title', content: title },
+      { name: 'twitter:description', content: description },
+    ]
 
-  if (absoluteImage) {
-    meta.push({ property: 'og:image', content: absoluteImage })
-    meta.push({ name: 'twitter:image', content: absoluteImage })
-  }
-
-  if (publishedTime) {
-    meta.push({ property: 'article:published_time', content: publishedTime })
-  }
-
-  if (modifiedTime) {
-    meta.push({ property: 'article:modified_time', content: modifiedTime })
-  }
-
-  if (authors && authors.length > 0) {
-    for (const author of authors) {
-      meta.push({ property: 'article:author', content: author })
+    if (absoluteImage) {
+      meta.push({ property: 'og:image', content: absoluteImage })
+      meta.push({ name: 'twitter:image', content: absoluteImage })
     }
-  }
 
-  if (noindex) {
-    meta.push({ name: 'robots', content: 'noindex, follow' })
-  }
+    if (publishedTime) {
+      meta.push({ property: 'article:published_time', content: publishedTime })
+    }
 
-  const link: Array<{ rel: string, href: string }> = [
-    { rel: 'canonical', href: absoluteUrl },
-  ]
+    if (modifiedTime) {
+      meta.push({ property: 'article:modified_time', content: modifiedTime })
+    }
 
-  const script: Array<{ type: string, innerHTML: string }> = []
+    if (authors && authors.length > 0) {
+      for (const author of authors) {
+        meta.push({ property: 'article:author', content: author })
+      }
+    }
 
-  if (jsonLd) {
-    script.push({
-      type: 'application/ld+json',
-      innerHTML: JSON.stringify(jsonLd),
-    })
-  }
+    if (noindex) {
+      meta.push({ name: 'robots', content: 'noindex, follow' })
+    }
 
-  useHead({
-    title,
-    meta,
-    link,
-    script,
+    const link: Array<{ rel: string, href: string }> = [
+      { rel: 'canonical', href: absoluteUrl },
+    ]
+
+    const script: Array<{ type: string, innerHTML: string }> = []
+
+    if (jsonLd) {
+      script.push({
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(jsonLd),
+      })
+    }
+
+    return {
+      title,
+      meta,
+      link,
+      script,
+    }
   })
 }

--- a/content.config.ts
+++ b/content.config.ts
@@ -1,4 +1,5 @@
 import { defineCollection, defineContentConfig, z } from '@nuxt/content'
+import { SEO_DESCRIPTION_MAX_LENGTH, SEO_TITLE_MAX_LENGTH } from './utils/seoLimits'
 
 export default defineContentConfig({
   collections: {
@@ -7,8 +8,10 @@ export default defineContentConfig({
       source: 'blogs/**/*.md',
       schema: z.object({
         title: z.string(),
+        seoTitle: z.string().max(SEO_TITLE_MAX_LENGTH).optional(),
         date: z.string(),
         description: z.string(),
+        seoDescription: z.string().max(SEO_DESCRIPTION_MAX_LENGTH).optional(),
         image: z.string().optional(),
         alt: z.string().optional(),
         ogImage: z.string().optional(),

--- a/content/blogs/2026-06-22-clean-architecture-avec-react-remettre-des-frontieres-dans-un-frontend-qui-grandit/index.md
+++ b/content/blogs/2026-06-22-clean-architecture-avec-react-remettre-des-frontieres-dans-un-frontend-qui-grandit/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Clean Architecture avec React : remettre des frontières dans un frontend qui grandit"
+seoTitle: "Clean Architecture React : structurer un frontend"
 date: 2026-06-22T13:31:39.593Z
 description: "Avez-vous déjà vu un frontend React devenir un monstre difficile à dompter ?  J’ai été amené à travailler sur plusieurs projets de refonte du frontend, et tous avaient le même problème.  Un composant "
+seoDescription: "Structurez un frontend React avec la Clean Architecture : couches, dépendances et frontières claires pour faire évoluer l’application sans dette."
 image: ./assets/cover-image.webp
 alt: "Du monstre spaghetti à la clean architecture avec react"
 ogImage: ./assets/cover-image.webp
@@ -489,4 +491,3 @@ Si le sujet t’intéresse, j’ai publié le code et les décisions d’archite
 Si tu veux challenger l’approche, t’en inspirer, ou simplement comparer avec ce que tu fais déjà en équipe, le plus simple est encore d’aller voir le lab, de parcourir les ADRs et de confronter cela à tes propres contraintes de terrain.
 
 Car au final, dans un projet frontend, ce n’est pas React le centre de l’application mais le besoin métier.
-

--- a/content/blogs/2026-06-22-devlille-2026-retour-sur-la-mise-en-place-denvironnements-qui-favorisent-la-progression/index.md
+++ b/content/blogs/2026-06-22-devlille-2026-retour-sur-la-mise-en-place-denvironnements-qui-favorisent-la-progression/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Devlille 2026 : Retour sur la mise en place d’environnements qui favorisent la progression"
+seoTitle: "DevLille 2026 : des équipes qui progressent"
 date: 2026-06-22T13:31:39.592Z
 description: "La semaine dernière, j'ai eu la chance d'assister à DevLille, l'un des rendez-vous incontournables de l'écosystème tech lillois. Au-delà des sujets purement techniques, plusieurs conférences ont parti"
+seoDescription: "Culture de l’erreur, expérience développeur et carrière des experts : les enseignements de DevLille 2026 pour créer des équipes qui apprennent."
 image: ./assets/cover-image.webp
 alt: "Photo de groupe au DevLille"
 ogImage: ./assets/cover-image.webp

--- a/content/blogs/2026-06-23-le-vert-ne-suffit-pas-3-facons-de-douter-de-son-code/index.md
+++ b/content/blogs/2026-06-23-le-vert-ne-suffit-pas-3-facons-de-douter-de-son-code/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Le vert ne suffit pas : 3 façons de douter de son code"
+seoTitle: "Tests au vert : trois techniques pour douter"
 date: 2026-06-23T07:27:57.384Z
 description: "Retour de DevLille 2026, côté Java/Kotlin/Springboot.  BUILD SUCCESS. Coverage à 98 %. Toute la suite de tests au vert. On connaît tous ce petit shot de dopamine du pipeline tout propre. Et on connaît"
+seoDescription: "Mutation testing, analyse statique et chaos engineering : trois techniques de DevLille pour vérifier ce que vos tests et votre code garantissent vraiment."
 image: ./assets/cover-image.webp
 alt: "Illustration de couverture pour l'article \"Le vert ne suffit pas\". Au centre, un grand badge vert fissuré affichant \"ALL TESTS GREEN : Coverage 98%\" avec une coche, entouré de flammes et de fumée : symbolisant une fausse confiance. Trois personnages cartoon l'entourent : à gauche, un petit monstre vert avec des cornes tenant un drapeau \"SURVIVED\" : représentant les mutants survivants du mutation testing ; au centre-bas, un petit robot bleu avec un point d'interrogation tenant un badge \"✅ COMPILES\" et l'air perplexe : représentant les limites de l'analyse statique ; à droite, un singe malicieux tirant des fils : représentant le Chaos Monkey et le chaos engineering. En bas, le titre en gras : \"Le vert ne suffit pas\". Fond bleu clair."
 ogImage: ./assets/cover-image.webp
@@ -313,4 +315,3 @@ Et il y a une raison de prendre ça au sérieux maintenant, plus qu'il y a deux 
 - [Chaos Monkey for Spring Boot](https://codecentric.github.io/chaos-monkey-spring-boot/latest/), [Resilience4j](https://resilience4j.readme.io/) et [Toxiproxy](https://github.com/Shopify/toxiproxy)
 
 - [Principles of Chaos Engineering](https://principlesofchaos.org/)
-

--- a/content/blogs/2026-06-29-quand-lia-rencontre-la-prod-retour-sur-les-talks-ia-du-devlille-2026-pt-1/index.md
+++ b/content/blogs/2026-06-29-quand-lia-rencontre-la-prod-retour-sur-les-talks-ia-du-devlille-2026-pt-1/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Quand l'IA rencontre la prod : retour sur les talks IA du DevLille 2026 (Pt 1)"
+seoTitle: "IA en production : les leçons de DevLille 2026"
 date: 2026-06-29T07:49:02.136Z
 description: "L'été pointe le bout de son nez, les terrasses se remplissent, les journées s'étirent jusque tard dans la soirée, et le DevLille fait son retour pour une nouvelle édition.  Les 11 et 12 juin 2026, le"
+seoDescription: "Agents IA, validation des LLM, spec coding et observabilité : les enseignements des talks IA de DevLille 2026 pour passer du prototype à la production."
 image: ./assets/cover-image.webp
 alt: "Photo de groupe de neuf membres de l'équipe HoppR portant des vêtements violets aux couleurs de l’entreprise, posant ensemble lors de l'événement DevLille."
 ogImage: ./assets/cover-image.webp
@@ -168,4 +170,3 @@ Pour ne rien manquer de la suite :
 - Suivez [HoppR sur LinkedIn](https://www.linkedin.com/company/hopprtech/?viewAsMember=true) pour être notifié·e de la publication des prochains articles.
 
 À très vite pour la partie 2 !
-

--- a/content/blogs/2026-06-30-tdd-jen-entends-beaucoup-parler-mais-cest-quoi-au-juste/index.md
+++ b/content/blogs/2026-06-30-tdd-jen-entends-beaucoup-parler-mais-cest-quoi-au-juste/index.md
@@ -1,7 +1,9 @@
 ---
 title: "TDD : J’en entends beaucoup parler, mais c’est quoi au juste ?"
+seoTitle: "TDD : comprendre le cycle Red Green Refactor"
 date: 2026-06-30T06:53:44.243Z
 description: "TDD ou Test-Driven Development… Ce terme revient souvent dans les discussions entre développeurs, dans les offres d’emploi, ou même lors des revues de code. \"On devrait adopter le TDD sur ce projet !\""
+seoDescription: "Comprenez le TDD, ses trois lois et le cycle Red Green Refactor avec un exemple Java pour concevoir du code par petits pas, au-delà du test-first."
 image: ./assets/cover-image.webp
 alt: "Une développeuse HoppR faisant du TDD en Java. Sur un de ses écrans, le fameux cycle red → green → refactor caractéristique du TDD. Sur l’autre, du code en Java."
 ogImage: ./assets/cover-image.webp

--- a/content/blogs/2026-07-02-pitcher-son-produit-et-vraiment-le-vendre-techniques-formats-et-secrets-du-terrain/index.md
+++ b/content/blogs/2026-07-02-pitcher-son-produit-et-vraiment-le-vendre-techniques-formats-et-secrets-du-terrain/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Pitcher son produit (et vraiment le vendre) : techniques, formats et secrets du terrain"
+seoTitle: "Comment construire un pitch produit convaincant"
 date: 2026-07-02T09:00:36.582Z
 description: "Mercredi 24 et jeudi 25 juin 2026, sous la canicule, j'étais à la dernière édition d'Agi'Lille. Je souhaite faire un retour d'expérience sur cet atelier que j'ai beaucoup aimé.  En binôme, nous avons"
+seoDescription: "Golden Circle, Hero’s Journey, objections et appel à l’action : des techniques concrètes pour structurer un pitch produit qui provoque une décision."
 image: ./assets/cover-image.webp
 alt: "Visuel de Emma en train de pitcher HoppR"
 ogImage: ./assets/cover-image.webp
@@ -204,6 +206,5 @@ Car un bon pitch n'est pas une démonstration d'éloquence. C'est la capacité �
 
 
 Et vous, quel framework utilisez-vous le plus au quotidien : **Golden Circle, Hero's Journey ou ABT** ? Ou en connaissez-vous d'autres qui ont fait leurs preuves ?
-
 
 

--- a/content/blogs/2026-07-08-souverainete-eco-conception-notre-rex-devlille-2026-pt-2/index.md
+++ b/content/blogs/2026-07-08-souverainete-eco-conception-notre-rex-devlille-2026-pt-2/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Souveraineté & éco-conception : notre REX DevLille 2026 (Pt 2)"
+seoTitle: "DevLille 2026 : souveraineté et éco-conception"
 date: 2026-07-08T09:39:41.771Z
 description: "On vous retrouve pour la partie 2 de nos retours du Devlille, cette fois ci orientés autour des notions de souveraineté et d’éco conception   Si vous avez manqué la partie 1, c’est par ici   Souverain"
+seoDescription: "Cinq retours de DevLille sur le cloud souverain, l’open source, l’auto-hébergement et l’éco-conception pour reprendre le contrôle de sa plateforme."
 image: ./assets/cover-image.webp
 alt: "Selfie de groupe de six membres de l'équipe HoppR souriants au DevLille. Ils portent des sweat-shirts violets de l'entreprise et posent ensemble dans le grand hall du centre de conférence."
 ogImage: ./assets/cover-image.webp
@@ -158,4 +160,3 @@ D'un talk à l'autre, le même constat s'impose : **la souveraineté et la sobri
 - Suivez [HoppR sur LinkedIn](https://www.linkedin.com/company/hopprtech/?viewAsMember=true) pour ne rien manquer de nos prochains contenus.
 
 À très vite pour la suite de nos retours !
-

--- a/content/blogs/2026-07-17-devlille-2026-pt3-ce-que-le-craft-nous-apprend-sur-nos-architectures/index.md
+++ b/content/blogs/2026-07-17-devlille-2026-pt3-ce-que-le-craft-nous-apprend-sur-nos-architectures/index.md
@@ -1,7 +1,9 @@
 ---
 title: "DevLille 2026 pt.3 : ce que le craft nous apprend sur nos architectures"
+seoTitle: "DevLille 2026 : craft, architecture et frontend"
 date: 2026-07-17T07:53:47.656Z
 description: "Dernière partie de nos retours du Devlille 2026 et cette fois-ci elle est consacrée au craft, à l’archi et au front end !  Vous pouvez retrouver la partie 1 ici et la partie 2 là.   On espère que vo"
+seoDescription: "Les enseignements craft de DevLille 2026 : interfaces pour agents, TanStack DB, architecture frontend et pratiques pour mieux concevoir nos applications."
 image: ./assets/cover-image.webp
 alt: "L'équipe HoppR, une douzaine de personnes en sweats à capuche violets floqués du logo, pose souriante devant un stand au Devlille 2026"
 ogImage: ./assets/cover-image.webp
@@ -203,4 +205,3 @@ C’est la fin de notre  retour sur le Devlille on espère que ça vous aura plu
 - Vous avez manqué le premier volet et le deuxième volet  ? Retrouvez notre [**REX DevLille 2026 sur l'intelligence artificielle**](https://blog.hoppr.tech/blogs/2026-06-29-quand-lia-rencontre-la-prod-retour-sur-les-talks-ia-du-devlille-2026-pt-1)  et …
 
 - Suivez [HoppR sur LinkedIn](https://www.linkedin.com/company/hopprtech/?viewAsMember=true) pour ne rien manquer de nos prochains contenus.
-

--- a/content/blogs/2026-07-24-llm-ce-qui-se-passe-vraiment-du-token-a-la-reponse/index.md
+++ b/content/blogs/2026-07-24-llm-ce-qui-se-passe-vraiment-du-token-a-la-reponse/index.md
@@ -1,7 +1,9 @@
 ---
 title: "LLM : ce qui se passe vraiment du token à la réponse"
+seoTitle: "Comment fonctionne un LLM, du token à la réponse"
 date: 2026-07-24T07:41:51.993Z
 description: "Vous saisissez une question et, quelques instants plus tard, une réponse structurée apparaît. Cette fluidité donne l’impression que le modèle a compris la demande, réfléchi, puis rédigé son texte comm"
+seoDescription: "Comprenez comment un LLM transforme des tokens en réponse : tokenisation, embeddings, attention, blocs Transformer, entraînement et génération."
 image: ./assets/cover-image.webp
 alt: "Du token à la réponse : représentation d’un LLM ouvert, avec des tokens traversant ses couches avant de devenir du texte."
 ogImage: ./assets/cover-image.webp

--- a/content/blogs/2026-07-28-property-based-testing-comment-bien-choisir-ses-proprietes-avec-kotest/index.md
+++ b/content/blogs/2026-07-28-property-based-testing-comment-bien-choisir-ses-proprietes-avec-kotest/index.md
@@ -1,7 +1,9 @@
 ---
 title: "Property based testing : comment bien choisir ses propriétés avec Kotest"
+seoTitle: "Property-based testing avec Kotest : 6 patterns"
 date: 2026-07-28T09:48:44.449Z
 description: "Un test unitaire, tout le monde connait : on choisit une entrée, on vérifie la sortie. `[3, 1, 2]` trié doit rendre `[1, 2, 3]`. C'est efficace, mais on ne teste que les cas qu'on a imaginés. Le prope"
+seoDescription: "Découvrez six patterns pour choisir des propriétés solides avec Kotest, générer des cas limites et éviter les tests trop faibles en Kotlin."
 image: ./assets/cover-image.webp
 alt: "Illustration isométrique violette sur fond blanc. Un cube central marqué f(x) représente la fonction testée, relié par des connecteurs verts à six tuiles hexagonales disposées en couronne, chacune validée par une coche verte et illustrant un pattern de property based testing : round-trip, idempotence, invariants, oracle, algebraic et easy to verify."
 ogImage: ./assets/cover-image.webp
@@ -433,4 +435,3 @@ Par où commencer dans une vraie codebase ? Je vise d'abord deux endroits : les 
 - [Choosing properties for property-based testing](https://fsharpforfunandprofit.com/posts/property-based-testing-2/), la source de ces patterns, par Scott Wlaschin. Il en liste sept, le septième porte sur les structures récursives
 
 - [jqwik](https://jqwik.net/) côté JUnit 5, comparé à Kotest dans mon REX
-

--- a/error.vue
+++ b/error.vue
@@ -1,0 +1,52 @@
+<script setup lang="ts">
+import type { NuxtError } from '#app'
+
+const props = defineProps<{
+  error: NuxtError
+}>()
+
+const isNotFound = computed(() => props.error.statusCode === 404)
+
+useHead(() => ({
+  title: isNotFound.value ? 'Page introuvable' : 'Une erreur est survenue',
+  meta: [
+    { name: 'robots', content: 'noindex, nofollow' },
+  ],
+}))
+
+async function returnHome() {
+  await clearError({ redirect: '/' })
+}
+</script>
+
+<template>
+  <NuxtLayout>
+    <section class="container max-w-xl mx-auto px-6 py-10 text-center">
+      <template v-if="isNotFound">
+        <h1 class="sr-only">
+          Page introuvable
+        </h1>
+        <Logo404 aria-hidden="true" />
+        <p class="mt-6 text-lg text-zinc-700 dark:text-zinc-300">
+          Cette page n’existe pas ou n’est plus disponible.
+        </p>
+      </template>
+      <template v-else>
+        <h1 class="text-3xl font-bold text-zinc-900 dark:text-zinc-100">
+          Une erreur est survenue
+        </h1>
+        <p class="mt-4 text-zinc-700 dark:text-zinc-300">
+          Le blog n’a pas pu afficher cette page.
+        </p>
+      </template>
+
+      <button
+        type="button"
+        class="mt-8 rounded-md bg-hoppr-green px-5 py-3 font-semibold text-hoppr-black transition hover:bg-opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-hoppr-purple focus-visible:ring-offset-2"
+        @click="returnHome"
+      >
+        Retour à l’accueil
+      </button>
+    </section>
+  </NuxtLayout>
+</template>

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -128,10 +128,6 @@ export default defineNuxtConfig({
         '/categories',
         '/tags',
         '/rss.xml',
-        '/categories/craft',
-        '/categories/cloud-platform',
-        '/categories/architecture',
-        '/categories/others',
       ],
       // Exclude OG image routes from prerendering (both legacy /__og-image__/**
       // and the new /_og/** path pattern emitted by nuxt-og-image v3+).
@@ -141,6 +137,27 @@ export default defineNuxtConfig({
       failOnError: false,
     },
     routeRules: {
+      // Query-string pagination must be rendered per request. A prerendered
+      // `/blogs` file is reused for every `?page=n` variant and would therefore
+      // serve page 1 content/canonical for the whole sequence.
+      '/blogs': {
+        prerender: false,
+      },
+      // Detail archives also support query-string pagination. Keep only the
+      // `/tags` and `/categories` hubs prerendered; render their children at
+      // runtime so direct page requests receive distinct HTML.
+      '/tags': {
+        prerender: true,
+      },
+      '/tags/**': {
+        prerender: false,
+      },
+      '/categories': {
+        prerender: true,
+      },
+      '/categories/**': {
+        prerender: false,
+      },
       '/insights/**': {
         cache: {
           maxAge: 60 * 60 * 24 * 7, // 7 jours en secondes

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build": "nuxt build",
     "dev": "NODE_OPTIONS='--disable-warning=DEP0040' NODE_ENV=development nuxt dev",
     "test": "bun test",
+    "test:e2e": "vitest run --config vitest.e2e.config.ts",
     "coverage": "npx vitest run --coverage",
     "generate": "nuxt generate",
     "preview": "nuxt preview",

--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -1,15 +1,7 @@
 <script setup lang="ts">
-defineOgImageComponent('About', {
-  headline: 'Wrong Path',
-  mainTitle: '404',
-  description: 'Page Not Found',
+throw createError({
+  status: 404,
+  statusText: 'Page introuvable',
+  fatal: true,
 })
 </script>
-
-<template>
-  <div class="py-5">
-    <div class="container max-w-xl   mx-auto">
-      <Logo404 />
-    </div>
-  </div>
-</template>

--- a/pages/blogs/[blog].vue
+++ b/pages/blogs/[blog].vue
@@ -18,8 +18,20 @@ const { data: article, error } = await useAsyncData(`blog-post-${path}`, () => {
 })
 
 if (error.value) {
-  console.error('Error fetching article:', error.value)
-  navigateTo('/404')
+  throw createError({
+    status: 500,
+    statusText: 'Impossible de charger cet article',
+    cause: error.value,
+    fatal: true,
+  })
+}
+
+if (!article.value || article.value.published !== true) {
+  throw createError({
+    status: 404,
+    statusText: 'Article introuvable',
+    fatal: true,
+  })
 }
 
 const blogPostProps = computed(() => {

--- a/pages/blogs/[blog].vue
+++ b/pages/blogs/[blog].vue
@@ -69,7 +69,11 @@ const reviewers: Person[] = (article.value?.reviewers || []).map(r => ({
   jobTitle: (r as { jobTitle?: string }).jobTitle,
   bio: (r as { bio?: string }).bio,
 }))
-const ogDescription = computed(() => stripMarkdown(blogPostProps.value.description))
+const seoTitle = computed(() => article.value?.seoTitle?.trim() || blogPostProps.value.title)
+const seoDescription = computed(() => {
+  const description = article.value?.seoDescription?.trim() || blogPostProps.value.description
+  return stripMarkdown(description)
+})
 
 const absoluteImage = computed(() => useAbsoluteUrl(blogPostProps.value.ogImage || blogPostProps.value.image))
 
@@ -97,7 +101,7 @@ const structuredData = computed(() => buildBlogPostingJsonLd({
   baseUrl,
   path: articlePath.value,
   title: blogPostProps.value.title,
-  description: ogDescription.value,
+  description: seoDescription.value,
   image: absoluteImage.value,
   datePublished: blogPostProps.value.date,
   dateModified: articleDateModified.value,
@@ -108,8 +112,8 @@ const structuredData = computed(() => buildBlogPostingJsonLd({
 }))
 
 usePageSeo({
-  title: blogPostProps.value.title || '',
-  description: ogDescription.value,
+  title: seoTitle,
+  description: seoDescription,
   url: path,
   image: blogPostProps.value.ogImage || blogPostProps.value.image,
   type: 'article',
@@ -139,8 +143,8 @@ if (extraJsonLdScripts.length > 0) {
 // Generate OG Image
 defineOgImageComponent('About', {
   headline: 'Bienvenue 👋',
-  mainTitle: blogPostProps.value.title || '',
-  description: ogDescription.value || '',
+  mainTitle: seoTitle.value,
+  description: seoDescription.value,
   imageTop: '/images/og-post.png',
   imageBottom: '/images/og-home.png',
 })

--- a/pages/blogs/index.vue
+++ b/pages/blogs/index.vue
@@ -1,8 +1,8 @@
 <script lang="ts" setup>
-import type { NuxtError } from 'nuxt/app'
 import { computed, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { usePageSeo } from '@/composables/usePageSeo'
+import { buildPaginationHeadLinks, resolvePageNumber } from '@/utils/pagination'
 
 const route = useRoute()
 const router = useRouter()
@@ -10,26 +10,25 @@ const { data, error } = await useAsyncData('all-blog-post', () =>
   queryCollection('blogs')
     .order('date', 'DESC')
     .all()
-    .catch((err: Error) => {
-      console.error('Erreur lors de la récupération des articles:', err)
-      error.value = { statusCode: 500, message: 'Impossible de charger les articles. Veuillez réessayer plus tard.' } as NuxtError
-      return []
-    }))
+    .then(articles => articles.filter(article => article.published === true)))
+
+if (error.value) {
+  throw createError({
+    status: 500,
+    statusText: 'Impossible de charger les articles',
+    cause: error.value,
+    fatal: true,
+  })
+}
 
 const elementPerPage = 12
-const pageNumber = computed(() => {
-  const p = Number(route.query.page)
-  return (Number.isFinite(p) && p >= 1) ? p : 1
-})
 const searchTest = ref('')
+const routeSearchTerm = computed(() => {
+  return typeof route.query.search === 'string' ? route.query.search.trim() : ''
+})
 
 watch(() => route.query.search, (newSearch) => {
-  if (newSearch) {
-    searchTest.value = newSearch as string
-  }
-  else {
-    searchTest.value = ''
-  }
+  searchTest.value = typeof newSearch === 'string' ? newSearch.trim() : ''
 }, { immediate: true })
 
 const formattedData = computed(() => {
@@ -68,17 +67,45 @@ const searchData = computed(() => {
   })
 })
 
+const totalPage = computed(() => {
+  const ttlContent = searchData.value?.length || 0
+  return Math.ceil(ttlContent / elementPerPage)
+})
+
+const routeSearchTotalPage = computed(() => {
+  const term = routeSearchTerm.value.toLowerCase()
+  const articles = formattedData.value || []
+  const total = term
+    ? articles.filter((article) => {
+      return article.title.toLowerCase().includes(term)
+        || article.description.toLowerCase().includes(term)
+        || article.content.toLowerCase().includes(term)
+        || article.tags.some((tag: string) => tag.toLowerCase().includes(term))
+        || article.authors.some((author: { name: string }) => author.name.toLowerCase().includes(term))
+    }).length
+    : articles.length
+
+  return Math.ceil(total / elementPerPage)
+})
+
+const pageNumber = computed(() => {
+  const page = resolvePageNumber(route.query.page, routeSearchTotalPage.value)
+  if (page === null) {
+    throw createError({
+      status: 404,
+      statusText: 'Page d’articles introuvable',
+      fatal: true,
+    })
+  }
+  return page
+})
+
 const paginatedData = computed(() => {
   return searchData.value?.filter((_data, idx) => {
     const startInd = ((pageNumber.value - 1) * elementPerPage)
     const endInd = (pageNumber.value * elementPerPage) - 1
     return idx >= startInd && idx <= endInd
   }) || []
-})
-
-const totalPage = computed(() => {
-  const ttlContent = searchData.value?.length || 0
-  return Math.ceil(ttlContent / elementPerPage)
 })
 
 function onPageChange(page: number) {
@@ -90,31 +117,36 @@ function onPageChange(page: number) {
   router.push({ path: '/blogs', query })
 }
 
+const hasSearchQuery = computed(() => {
+  return routeSearchTerm.value.length > 0
+})
+
+const paginationQuery = computed<Record<string, string>>(() => {
+  return searchTest.value ? { search: searchTest.value } : {}
+})
+
 const canonicalUrl = computed(() => {
+  if (hasSearchQuery.value)
+    return '/blogs'
   return pageNumber.value > 1 ? `/blogs?page=${pageNumber.value}` : '/blogs'
 })
 
 const prevNextLinks = computed(() => {
-  const links: Array<{ rel: string, href: string }> = []
-  if (pageNumber.value > 1) {
-    const prevPage = pageNumber.value === 2 ? '/blogs' : `/blogs?page=${pageNumber.value - 1}`
-    links.push({ rel: 'prev', href: prevPage })
-  }
-  if (pageNumber.value < totalPage.value) {
-    links.push({ rel: 'next', href: `/blogs?page=${pageNumber.value + 1}` })
-  }
-  return links
+  if (hasSearchQuery.value)
+    return []
+  return buildPaginationHeadLinks('/blogs', pageNumber.value, totalPage.value)
 })
 
 usePageSeo({
   title: 'Tous nos Articles',
   description: 'Toutes les publications sur le blog d\'HoppR sont ici. Découvrez nos articles sur le Software Craftsmanship, le Cloud, l\'Architecture et la Tech.',
-  url: canonicalUrl.value,
+  url: canonicalUrl,
+  noindex: hasSearchQuery,
 })
 
-useHead({
+useHead(() => ({
   link: prevNextLinks.value,
-})
+}))
 
 // Generate OG Image — defineOgImageComponent + nom de composant explicite,
 // sinon unhead plante "originalName.split is not a function" → 500 SSR.
@@ -127,10 +159,6 @@ defineOgImageComponent('About', {
 <template>
   <main class="container max-w-6xl mx-auto text-zinc-600">
     <ArchiveHero />
-
-    <div v-if="error" class="px-6 py-4 bg-red-100 border border-red-400 text-red-700 rounded">
-      {{ error }}
-    </div>
 
     <div class="px-6">
       <label for="search-input" class="sr-only">Rechercher un article</label>
@@ -150,9 +178,6 @@ defineOgImageComponent('About', {
       <BlogLoader />
       <BlogLoader />
     </div>
-    <div v-else-if="error" class="space-y-5 my-5 px-4">
-      <p>{{ error }}</p>
-    </div>
     <div v-else class="space-y-5 my-5 px-4">
       <template v-for="post in paginatedData" :key="post.title">
         <ArchiveCard
@@ -170,6 +195,7 @@ defineOgImageComponent('About', {
       :current-page="pageNumber"
       :total-pages="totalPage"
       base-url="/blogs"
+      :query="paginationQuery"
       @page-change="onPageChange"
     />
   </main>

--- a/pages/categories/[category].vue
+++ b/pages/categories/[category].vue
@@ -3,24 +3,42 @@ import { useAbsoluteUrl } from '@/composables/useAbsoluteUrl'
 import { usePageSeo } from '@/composables/usePageSeo'
 import { categories } from '@/utils/categories'
 import { wrapInGraph } from '@/utils/organization'
+import { buildPaginationHeadLinks, resolvePageNumber } from '@/utils/pagination'
+
+definePageMeta({
+  key: route => route.path,
+})
 
 const route = useRoute()
 const router = useRouter()
-const categoryValue = computed(() => route.params.category as string)
+const routeCategory = route.params.category
+const categoryValue = Array.isArray(routeCategory) ? routeCategory.at(0) || '' : routeCategory || ''
+const category = categories.find(cat => cat.value === categoryValue)
 
-const category = computed(() => {
-  return categories.find(cat => cat.value === categoryValue.value) || {
-    label: categoryValue.value,
-    icon: 'mdi:tag',
-    colors: { light: '#3b82f6', dark: '#60A5FA' },
-    seoDescription: `Articles HoppR dans la catégorie ${categoryValue.value}.`,
-  }
+if (!category) {
+  throw createError({
+    status: 404,
+    statusText: 'Catégorie introuvable',
+    fatal: true,
+  })
+}
+
+const { data, error } = await useAsyncData(`category-${categoryValue}`, async () => {
+  const allPosts = await queryCollection('blogs').order('date', 'DESC').all()
+  return allPosts.filter(article =>
+    article.published === true
+    && article.tags?.some(tag => tag.toLowerCase() === categoryValue.toLowerCase()),
+  )
 })
 
-const { data } = await useAsyncData(`category-${categoryValue.value}`, async () => {
-  const allPosts = await queryCollection('blogs').all()
-  return allPosts.filter(article => article.tags?.includes(categoryValue.value))
-})
+if (error.value) {
+  throw createError({
+    status: 500,
+    statusText: 'Impossible de charger cette catégorie',
+    cause: error.value,
+    fatal: true,
+  })
+}
 
 const formattedData = computed(() => {
   return data.value?.map((article) => {
@@ -40,9 +58,21 @@ const formattedData = computed(() => {
 
 const elementPerPage = 12
 
+const totalPages = computed(() => {
+  const ttlContent = formattedData.value?.length || 0
+  return Math.ceil(ttlContent / elementPerPage)
+})
+
 const pageNumber = computed(() => {
-  const p = Number(route.query.page)
-  return (Number.isFinite(p) && p >= 1) ? p : 1
+  const page = resolvePageNumber(route.query.page, totalPages.value)
+  if (page === null) {
+    throw createError({
+      status: 404,
+      statusText: 'Page de catégorie introuvable',
+      fatal: true,
+    })
+  }
+  return page
 })
 
 const paginatedData = computed(() => {
@@ -53,38 +83,24 @@ const paginatedData = computed(() => {
   }) || []
 })
 
-const totalPages = computed(() => {
-  const ttlContent = formattedData.value?.length || 0
-  return Math.ceil(ttlContent / elementPerPage)
-})
-
 function onPageChange(page: number) {
   router.push({
-    path: `/categories/${categoryValue.value}`,
+    path: `/categories/${categoryValue}`,
     query: { ...(page > 1 && { page: String(page) }) },
   })
 }
 
 const canonicalUrl = computed(() => {
-  const base = `/categories/${categoryValue.value}`
+  const base = `/categories/${categoryValue}`
   return pageNumber.value > 1 ? `${base}?page=${pageNumber.value}` : base
 })
 
 const prevNextLinks = computed(() => {
-  const base = `/categories/${categoryValue.value}`
-  const links: Array<{ rel: string, href: string }> = []
-  if (pageNumber.value > 1) {
-    const prevPage = pageNumber.value === 2 ? base : `${base}?page=${pageNumber.value - 1}`
-    links.push({ rel: 'prev', href: prevPage })
-  }
-  if (pageNumber.value < totalPages.value) {
-    links.push({ rel: 'next', href: `${base}?page=${pageNumber.value + 1}` })
-  }
-  return links
+  return buildPaginationHeadLinks(`/categories/${categoryValue}`, pageNumber.value, totalPages.value)
 })
 
 const seoDescription = computed(() => {
-  const base = category.value.seoDescription
+  const base = category.seoDescription
   const count = formattedData.value?.length ?? 0
   return count > 0 ? `${base} ${count} articles publiés.` : base
 })
@@ -92,30 +108,32 @@ const seoDescription = computed(() => {
 const categoryBaseUrl = useAbsoluteUrl('/')
 const categoryTrimmedBase = categoryBaseUrl.replace(/\/$/, '')
 
+const categoryJsonLd = computed(() => wrapInGraph(categoryBaseUrl, {
+  '@context': 'https://schema.org',
+  '@type': 'CollectionPage',
+  '@id': `${categoryTrimmedBase}/categories/${categoryValue}#collectionpage`,
+  'url': `${categoryTrimmedBase}/categories/${categoryValue}`,
+  'name': `Catégorie : ${category.label}`,
+  'description': seoDescription.value,
+  'inLanguage': 'fr-FR',
+  'isPartOf': { '@id': `${categoryTrimmedBase}/#website` },
+  'about': { '@id': 'https://hoppr.tech/#organization' },
+}))
+
 usePageSeo({
-  title: `Articles ${category.value.label}`,
-  description: seoDescription.value,
-  url: canonicalUrl.value,
-  jsonLd: wrapInGraph(categoryBaseUrl, {
-    '@context': 'https://schema.org',
-    '@type': 'CollectionPage',
-    '@id': `${categoryTrimmedBase}/categories/${categoryValue.value}#collectionpage`,
-    'url': `${categoryTrimmedBase}/categories/${categoryValue.value}`,
-    'name': `Catégorie : ${category.value.label}`,
-    'description': seoDescription.value,
-    'inLanguage': 'fr-FR',
-    'isPartOf': { '@id': `${categoryTrimmedBase}/#website` },
-    'about': { '@id': 'https://hoppr.tech/#organization' },
-  }),
+  title: `Articles ${category.label}`,
+  description: seoDescription,
+  url: canonicalUrl,
+  jsonLd: categoryJsonLd,
 })
 
-useHead({
+useHead(() => ({
   link: prevNextLinks.value,
-})
+}))
 
 // Generate OG Image
 defineOgImage('About', {
-  mainTitle: `Catégorie: ${category.value.label}`,
+  mainTitle: `Catégorie: ${category.label}`,
   description: seoDescription.value,
 })
 </script>

--- a/pages/categories/index.vue
+++ b/pages/categories/index.vue
@@ -8,7 +8,8 @@ import { categories } from '@/utils/categories'
 // jamais propager une éventuelle erreur SQLite en 500 sur la route.
 const { data } = await useAsyncData('all-blog-posts-categories', async () => {
   try {
-    return await queryCollection('blogs').order('date', 'DESC').all()
+    const articles = await queryCollection('blogs').order('date', 'DESC').all()
+    return articles.filter(article => article.published === true)
   }
   catch (err) {
     console.error('[categories/index] queryCollection failed', err)

--- a/pages/tags/[tag].vue
+++ b/pages/tags/[tag].vue
@@ -1,27 +1,44 @@
 <script lang="ts" setup>
 import { usePageSeo } from '@/composables/usePageSeo'
+import { buildPaginationHeadLinks, resolvePageNumber } from '@/utils/pagination'
 import { capitalize } from '@/utils/stringUtils'
+
+definePageMeta({
+  key: route => route.path,
+})
 
 const route = useRoute()
 const router = useRouter()
 
-const tag = computed(() => {
-  const name = route.params.tag || ''
-  let strName = ''
-
-  if (Array.isArray(name))
-    strName = name.at(0) || ''
-  else
-    strName = name
-  return strName.toLowerCase()
-})
+const routeTag = route.params.tag
+const tag = (Array.isArray(routeTag) ? routeTag.at(0) : routeTag)?.toLowerCase() || ''
 
 const MIN_ARTICLES_FOR_INDEX = 3
 
-const { data } = await useAsyncData(`tag-data-${tag.value}`, async () => {
-  const allPosts = await queryCollection('blogs').all()
-  return allPosts.filter(article => article.tags?.includes(tag.value))
+const { data, error } = await useAsyncData(`tag-data-${tag}`, async () => {
+  const allPosts = await queryCollection('blogs').order('date', 'DESC').all()
+  return allPosts.filter(article =>
+    article.published === true
+    && article.tags?.some(articleTag => articleTag.toLowerCase() === tag),
+  )
 })
+
+if (error.value) {
+  throw createError({
+    status: 500,
+    statusText: 'Impossible de charger ce tag',
+    cause: error.value,
+    fatal: true,
+  })
+}
+
+if (!tag || !data.value || data.value.length === 0) {
+  throw createError({
+    status: 404,
+    statusText: 'Tag introuvable',
+    fatal: true,
+  })
+}
 
 const formattedData = computed(() => {
   return data.value?.map((articles) => {
@@ -41,9 +58,21 @@ const formattedData = computed(() => {
 
 const elementPerPage = 12
 
+const totalPages = computed(() => {
+  const ttlContent = formattedData.value?.length || 0
+  return Math.ceil(ttlContent / elementPerPage)
+})
+
 const pageNumber = computed(() => {
-  const p = Number(route.query.page)
-  return (Number.isFinite(p) && p >= 1) ? p : 1
+  const page = resolvePageNumber(route.query.page, totalPages.value)
+  if (page === null) {
+    throw createError({
+      status: 404,
+      statusText: 'Page de tag introuvable',
+      fatal: true,
+    })
+  }
+  return page
 })
 
 const paginatedData = computed(() => {
@@ -54,14 +83,9 @@ const paginatedData = computed(() => {
   }) || []
 })
 
-const totalPages = computed(() => {
-  const ttlContent = formattedData.value?.length || 0
-  return Math.ceil(ttlContent / elementPerPage)
-})
-
 function onPageChange(page: number) {
   router.push({
-    path: `/tags/${tag.value}`,
+    path: `/tags/${tag}`,
     query: { ...(page > 1 && { page: String(page) }) },
   })
 }
@@ -69,33 +93,24 @@ function onPageChange(page: number) {
 const shouldNoindex = computed(() => (data.value?.length || 0) < MIN_ARTICLES_FOR_INDEX)
 
 const canonicalUrl = computed(() => {
-  const base = `/tags/${tag.value}`
+  const base = `/tags/${tag}`
   return pageNumber.value > 1 ? `${base}?page=${pageNumber.value}` : base
 })
 
 const prevNextLinks = computed(() => {
-  const base = `/tags/${tag.value}`
-  const links: Array<{ rel: string, href: string }> = []
-  if (pageNumber.value > 1) {
-    const prevPage = pageNumber.value === 2 ? base : `${base}?page=${pageNumber.value - 1}`
-    links.push({ rel: 'prev', href: prevPage })
-  }
-  if (pageNumber.value < totalPages.value) {
-    links.push({ rel: 'next', href: `${base}?page=${pageNumber.value + 1}` })
-  }
-  return links
+  return buildPaginationHeadLinks(`/tags/${tag}`, pageNumber.value, totalPages.value)
 })
 
 const MAX_RECENT_TITLES_IN_DESCRIPTION = 3
 const MAX_TITLE_CHARS = 40
 
-const tagLabel = computed(() => capitalize(tag.value))
+const tagLabel = capitalize(tag)
 
 const seoDescription = computed(() => {
   const count = data.value?.length ?? 0
 
   if (count === 0)
-    return `Articles HoppR tagués "${tag.value}" — Software Craftsmanship, Cloud et Architecture par l'équipe tech HoppR.`
+    return `Articles HoppR tagués "${tag}" — Software Craftsmanship, Cloud et Architecture par l'équipe tech HoppR.`
 
   const recentTitles = (data.value ?? [])
     .slice(0, MAX_RECENT_TITLES_IN_DESCRIPTION)
@@ -106,24 +121,24 @@ const seoDescription = computed(() => {
     .filter((t): t is string => t.length > 0)
 
   const titlesPart = recentTitles.length > 0 ? ` Récents : ${recentTitles.join(' · ')}.` : ''
-  return `${count} article${count > 1 ? 's' : ''} HoppR tagué${count > 1 ? 's' : ''} "${tag.value}".${titlesPart}`
+  return `${count} article${count > 1 ? 's' : ''} HoppR tagué${count > 1 ? 's' : ''} "${tag}".${titlesPart}`
 })
 
 usePageSeo({
-  title: tagLabel.value,
-  description: seoDescription.value,
-  url: canonicalUrl.value,
-  noindex: shouldNoindex.value,
+  title: tagLabel,
+  description: seoDescription,
+  url: canonicalUrl,
+  noindex: shouldNoindex,
 })
 
-useHead({
+useHead(() => ({
   link: prevNextLinks.value,
-})
+}))
 
 // Generate OG Image — defineOgImageComponent + nom de composant explicite,
 // sinon unhead plante "originalName.split is not a function" → 500 SSR.
 defineOgImageComponent('About', {
-  title: tagLabel.value,
+  title: tagLabel,
   description: seoDescription.value,
 })
 </script>

--- a/pages/tags/index.vue
+++ b/pages/tags/index.vue
@@ -7,7 +7,8 @@ import { makeFirstCharUpper } from '../../utils/helper'
 // ne jamais propager une éventuelle erreur SQLite en 500 sur la route.
 const { data } = await useAsyncData('all-blog-posts-tags', async () => {
   try {
-    return await queryCollection('blogs').order('date', 'DESC').all()
+    const articles = await queryCollection('blogs').order('date', 'DESC').all()
+    return articles.filter(article => article.published === true)
   }
   catch (err) {
     console.error('[tags/index] queryCollection failed', err)
@@ -58,7 +59,9 @@ defineOgImageComponent('About', {
   <main class="container max-w-5xl mx-auto text-zinc-600">
     <TagHero />
     <div class="px-6 mt-8">
+      <label for="tag-search" class="sr-only">Rechercher un tag</label>
       <input
+        id="tag-search"
         v-model="searchQuery" type="text" placeholder="Rechercher un tag"
         class="block w-full bg-[#F1F2F4] dark:bg-slate-900 dark:placeholder-zinc-500 text-zinc-800 dark:text-zinc-300 rounded-md border-gray-300 dark:border-zinc-500 shadow-sm focus:border-hoppr-green focus:ring focus:ring-hoppr-green focus:ring-opacity-50"
       >

--- a/server/services/github/postChecker.test.ts
+++ b/server/services/github/postChecker.test.ts
@@ -68,6 +68,30 @@ describe('postChecker', () => {
     })
   })
 
+  describe('check SEO metadata', () => {
+    it('should reject an SEO title that makes the rendered title exceed 60 characters', () => {
+      const post = buildDefaultPost()
+      post.seoTitle = 'A'.repeat(53)
+
+      expect(() => checkPost(post)).toThrowError('SEO Title must be 52 characters or fewer')
+    })
+
+    it('should reject an SEO description longer than 160 characters', () => {
+      const post = buildDefaultPost()
+      post.seoDescription = 'A'.repeat(161)
+
+      expect(() => checkPost(post)).toThrowError('SEO Description must be 160 characters or fewer')
+    })
+
+    it('should accept SEO metadata within the recommended limits', () => {
+      const post = buildDefaultPost()
+      post.seoTitle = 'A'.repeat(52)
+      post.seoDescription = 'A'.repeat(160)
+
+      expect(() => checkPost(post)).not.toThrowError()
+    })
+  })
+
   describe('check blocks', () => {
     const paragraphBlock = buildDefaultParagraphBlock()
     const heading1Block = buildDefaultHeading1Block()

--- a/server/services/github/postChecker.ts
+++ b/server/services/github/postChecker.ts
@@ -1,11 +1,13 @@
 import type { BlockObjectResponse } from '@notionhq/client/build/src/api-endpoints'
 import type { BlogPost } from '@/types/blog'
+import { SEO_DESCRIPTION_MAX_LENGTH, SEO_TITLE_MAX_LENGTH } from '@/utils/seoLimits'
 
 export function checkPost(post: BlogPost) {
   checkImage(post.image)
   checkDate(post.date)
   checkContent(post.content)
   checkTags(post.tags)
+  checkSeoMetadata(post)
 }
 
 function checkImage(image: string) {
@@ -34,11 +36,21 @@ function checkTags(tags: string[]) {
     throw new Error(`Tag "${invalidTag}" contains an apostrophe ('), which breaks the article frontmatter. Rename the tag in Notion before publishing.`)
 }
 
+function checkSeoMetadata(post: BlogPost) {
+  if (post.seoTitle && post.seoTitle.trim().length > SEO_TITLE_MAX_LENGTH) {
+    throw new Error(`SEO Title must be ${SEO_TITLE_MAX_LENGTH} characters or fewer so the HoppR suffix stays within 60 characters.`)
+  }
+
+  if (post.seoDescription && post.seoDescription.trim().length > SEO_DESCRIPTION_MAX_LENGTH) {
+    throw new Error(`SEO Description must be ${SEO_DESCRIPTION_MAX_LENGTH} characters or fewer.`)
+  }
+}
+
 export function checkBlocks(blocks: BlockObjectResponse[]) {
   const firstBlock = blocks[0]
   if (!firstBlock)
     throw new Error('Content is empty')
-  if (firstBlock.type != 'heading_1' && firstBlock.type != 'paragraph')
+  if (firstBlock.type !== 'heading_1' && firstBlock.type !== 'paragraph')
     throw new Error('An article must start with a title or an introduction')
 
   if (blocks.slice(1).some(b => b.type === 'heading_1'))

--- a/server/services/notion/descriptionGenerator.ts
+++ b/server/services/notion/descriptionGenerator.ts
@@ -1,13 +1,21 @@
+import { SEO_DESCRIPTION_MAX_LENGTH } from '@/utils/seoLimits'
 import { stripMarkdown } from '@/utils/stringUtils'
 
-export function generateDescription(content: string): string {
-  const cleaned = stripMarkdown(
-    content.replace(/#.*\n/g, '').replace(/\n/g, ' '),
-  )
-  const limit = 200
+const MARKDOWN_HEADING = /^#{1,6}(?:\s|$)/
 
-  if (cleaned.length <= limit)
+export function generateDescription(content: string): string {
+  const contentWithoutHeadings = content
+    .split('\n')
+    .filter(line => !MARKDOWN_HEADING.test(line.trimStart()))
+    .join(' ')
+  const cleaned = stripMarkdown(contentWithoutHeadings).replace(/\s+/g, ' ').trim()
+
+  if (cleaned.length <= SEO_DESCRIPTION_MAX_LENGTH)
     return cleaned
 
-  return cleaned.substring(0, limit)
+  const candidate = cleaned.slice(0, SEO_DESCRIPTION_MAX_LENGTH - 1).trimEnd()
+  const lastSpace = candidate.lastIndexOf(' ')
+  const truncated = lastSpace > 0 ? candidate.slice(0, lastSpace) : candidate
+
+  return `${truncated}…`
 }

--- a/server/services/notion/markdownGenerator.test.ts
+++ b/server/services/notion/markdownGenerator.test.ts
@@ -7,8 +7,10 @@ describe('markdown Utils', () => {
     const post: BlogPost = {
       notionId: '1',
       title: 'Test Title',
+      seoTitle: 'Concise SEO title',
       date: new Date('2024-08-02T15:59:20.808Z').toISOString(),
       description: 'This is a test description.',
+      seoDescription: 'A specific description for search results.',
       image: 'http://example.com/image.jpg',
       alt: 'Test Image',
       ogImage: 'http://example.com/og-image.jpg',
@@ -23,8 +25,10 @@ describe('markdown Utils', () => {
 
     expect(markdown).toContain('---')
     expect(markdown).toContain(`title: "${post.title}"`)
+    expect(markdown).toContain(`seoTitle: "${post.seoTitle}"`)
     expect(markdown).toContain(`date: ${post.date}`)
     expect(markdown).toContain(`description: "${post.description}"`)
+    expect(markdown).toContain(`seoDescription: "${post.seoDescription}"`)
     expect(markdown).toContain('image: ./assets/cover-image.webp')
     expect(markdown).toContain(`alt: "${post.alt}"`)
     expect(markdown).toContain(`tags: [${post.tags.map(tag => `'${tag}'`).join(', ')}]`)
@@ -52,6 +56,8 @@ describe('markdown Utils', () => {
 
     expect(markdown).toContain('---')
     expect(markdown).toContain(`title: "${post.title}"`)
+    expect(markdown).not.toContain('seoTitle:')
+    expect(markdown).not.toContain('seoDescription:')
     expect(markdown).toContain('---')
     expect(markdown).toContain(content)
   })

--- a/server/services/notion/markdownGenerator.ts
+++ b/server/services/notion/markdownGenerator.ts
@@ -7,23 +7,30 @@ export function generateMarkdownContent(post: BlogPost, content: string): string
 function createFrontmatter(post: BlogPost, assetsFolder: string = './assets'): string {
   const formattedAuthors = formatPersons(post.authors)
   const formattedReviewers = formatPersons(post.reviewers)
-  return `---
-title: ${escapeYaml(post.title)}
-date: ${post.date}
-description: ${escapeYaml(post.description)}
-image: ${assetsFolder}/cover-image.webp
-alt: ${escapeYaml(post.alt)}
-ogImage: ${assetsFolder}/cover-image.webp
-tags: [${post.tags.map(tag => `'${tag.toLowerCase()}'`).join(', ')}]
-published: ${post.published}
-authors:
-${formattedAuthors}
-reviewers:
-${formattedReviewers}
----
+  const seoTitle = post.seoTitle?.trim()
+  const seoDescription = post.seoDescription?.trim()
+  const fields = [
+    '---',
+    `title: ${escapeYaml(post.title)}`,
+    ...(seoTitle ? [`seoTitle: ${escapeYaml(seoTitle)}`] : []),
+    `date: ${post.date}`,
+    `description: ${escapeYaml(post.description)}`,
+    ...(seoDescription ? [`seoDescription: ${escapeYaml(seoDescription)}`] : []),
+    `image: ${assetsFolder}/cover-image.webp`,
+    `alt: ${escapeYaml(post.alt)}`,
+    `ogImage: ${assetsFolder}/cover-image.webp`,
+    `tags: [${post.tags.map(tag => `'${tag.toLowerCase()}'`).join(', ')}]`,
+    `published: ${post.published}`,
+    'authors:',
+    formattedAuthors,
+    'reviewers:',
+    formattedReviewers,
+    '---',
+    '',
+    '<!-- markdownlint-disable-file -->',
+  ]
 
-<!-- markdownlint-disable-file -->
-`
+  return `${fields.join('\n')}\n`
 }
 
 // Wrap a string as a YAML double-quoted scalar that is always valid: escape

--- a/server/services/notion/pageContentExtractor.test.ts
+++ b/server/services/notion/pageContentExtractor.test.ts
@@ -113,6 +113,12 @@ describe('pageContentExtractor', () => {
         'Cover Image Alt': {
           rich_text: [],
         },
+        'SEO Title': {
+          rich_text: [{ plain_text: 'A concise ' }, { plain_text: 'SEO title' }],
+        },
+        'SEO Description': {
+          rich_text: [{ plain_text: 'A unique search description.' }],
+        },
       },
     }
 
@@ -123,6 +129,8 @@ describe('pageContentExtractor', () => {
 
     expect(content.notionId).toBe('page-id')
     expect(content.title).toBe('Test Title')
+    expect(content.seoTitle).toBe('A concise SEO title')
+    expect(content.seoDescription).toBe('A unique search description.')
     expect(content.content).toContain('Hello\n\n')
     expect(content.authors).toBeDefined()
     expect(content.authors.length).toBe(1)
@@ -168,7 +176,7 @@ describe('pageContentExtractor', () => {
     const mockClient = {
       blocks: {
         children: {
-          list: ({ block_id, start_cursor }): Promise<ListBlockChildrenResponse> => {
+          list: ({ block_id: _blockId, start_cursor }): Promise<ListBlockChildrenResponse> => {
             if (!start_cursor) {
               return Promise.resolve({
                 object: 'list' as const,

--- a/server/services/notion/pageContentExtractor.ts
+++ b/server/services/notion/pageContentExtractor.ts
@@ -20,10 +20,14 @@ export async function getPageContent(notionClient: NotionClientInterface, page: 
     const tagsNames = extractTags(page)
     const coverImage = extractCoverImage(page)
     const coverImageAlt = extractCoverImageAlt(page)
+    const seoTitle = extractOptionalRichText(page, 'SEO Title')
+    const seoDescription = extractOptionalRichText(page, 'SEO Description')
 
     return {
       notionId: page.id,
       title: extractTitleFromPage(page),
+      seoTitle,
+      seoDescription,
       authors,
       reviewers,
       coverImage,
@@ -68,6 +72,16 @@ function extractCoverImage(page: NotionPage) {
 
 function extractCoverImageAlt(page: NotionPage) {
   return safeGetProperty(page, ['properties', 'Cover Image Alt', 'rich_text', '0', 'plain_text'], '')
+}
+
+function extractOptionalRichText(page: NotionPage, propertyName: 'SEO Title' | 'SEO Description'): string | undefined {
+  const property = page.properties[propertyName]
+  const value = property?.rich_text
+    ?.map(text => text.plain_text)
+    .join('')
+    .trim()
+
+  return value || undefined
 }
 
 export async function fetchAllBlocks({ notionClient, page, nextPageCursor }: {
@@ -120,7 +134,6 @@ async function processBlocks(
 
 async function processTableBlock(notionClient: NotionClientInterface, block: BlockObjectResponse): Promise<void> {
   try {
-    console.log(`Fetching children for table block ${block.id}`)
     const tableRows = await notionClient.blocks.children.list({ block_id: block.id })
 
     if (!hasTableRows(tableRows)) {
@@ -129,7 +142,6 @@ async function processTableBlock(notionClient: NotionClientInterface, block: Blo
     }
 
     const firstRow = tableRows.results[0]
-    console.log('Structure de la première ligne:', JSON.stringify(firstRow, null, 2))
 
     if (isValidTableRow(firstRow)) {
       addFormattedRowsToTable(block, tableRows)
@@ -155,7 +167,6 @@ function isValidTableRow(row: any): boolean {
 }
 
 function addFormattedRowsToTable(block: BlockObjectResponse, tableRows: any): void {
-  console.log('Adapting table rows from table_row format')
   const formattedRows = tableRows.results
     .filter((row: any) => row.type === 'table_row')
     .map((row: any) => ({
@@ -163,12 +174,10 @@ function addFormattedRowsToTable(block: BlockObjectResponse, tableRows: any): vo
     }));
 
   ((block as any).table as any).children = formattedRows
-  console.log(`Added ${formattedRows.length} formatted rows to table block`)
 }
 
 function addOriginalRowsToTable(block: BlockObjectResponse, tableRows: any): void {
   ((block as any).table as any).children = tableRows.results.filter(isBlockObjectResponse)
-  console.log(`Added ${((block as any).table as any).children.length} original rows to table block`)
 }
 
 export function extractTitleFromPage(page: NotionPage): string {

--- a/server/services/notion/postRepository.test.ts
+++ b/server/services/notion/postRepository.test.ts
@@ -4,41 +4,50 @@ import { generateDescription } from './descriptionGenerator'
 describe('generateDescription', () => {
   it('should strip bold markdown from description', () => {
     const content = 'Chez **HoppR**, nous pensons\n'
-    expect(generateDescription(content)).toBe('Chez HoppR, nous pensons ')
+    expect(generateDescription(content)).toBe('Chez HoppR, nous pensons')
   })
 
   it('should strip italic markdown with underscores from description', () => {
     const content = 'le _Software Craftsmanship_ a rappelé\n'
-    expect(generateDescription(content)).toBe('le Software Craftsmanship a rappelé ')
+    expect(generateDescription(content)).toBe('le Software Craftsmanship a rappelé')
   })
 
   it('should strip italic markdown with asterisks from description', () => {
     const content = 'le *Software Craftsmanship* a rappelé\n'
-    expect(generateDescription(content)).toBe('le Software Craftsmanship a rappelé ')
+    expect(generateDescription(content)).toBe('le Software Craftsmanship a rappelé')
   })
 
   it('should strip bold+italic markdown from description', () => {
     const content = 'le ***Software Craftsmanship*** a rappelé\n'
-    expect(generateDescription(content)).toBe('le Software Craftsmanship a rappelé ')
+    expect(generateDescription(content)).toBe('le Software Craftsmanship a rappelé')
   })
 
   it('should replace markdown links with their label text', () => {
     const content = 'Voir [notre site](https://hoppr.tech) pour plus\n'
-    expect(generateDescription(content)).toBe('Voir notre site pour plus ')
+    expect(generateDescription(content)).toBe('Voir notre site pour plus')
   })
 
   it('should strip all markdown formatting combined', () => {
     const content = 'Le **Platform _Engineering_** avec [HoppR](https://hoppr.tech)\n'
-    expect(generateDescription(content)).toBe('Le Platform Engineering avec HoppR ')
+    expect(generateDescription(content)).toBe('Le Platform Engineering avec HoppR')
   })
 
   it('should still remove headings and newlines', () => {
     const content = '# Titre\nDu texte simple\n'
-    expect(generateDescription(content)).toBe('Du texte simple ')
+    expect(generateDescription(content)).toBe('Du texte simple')
   })
 
-  it('should still truncate to 200 characters', () => {
+  it('should limit generated descriptions to 160 characters', () => {
     const content = `${'A'.repeat(250)}\n`
-    expect(generateDescription(content)).toHaveLength(200)
+    expect(generateDescription(content)).toHaveLength(160)
+    expect(generateDescription(content)).toEndWith('…')
+  })
+
+  it('should truncate at a word boundary', () => {
+    const content = `${'mot '.repeat(60)}fin`
+    const description = generateDescription(content)
+
+    expect(description.length).toBeLessThanOrEqual(160)
+    expect(description).toEndWith('mot…')
   })
 })

--- a/tests/e2e/seo-rendering.e2e.ts
+++ b/tests/e2e/seo-rendering.e2e.ts
@@ -1,0 +1,132 @@
+import { fileURLToPath } from 'node:url'
+import { fetch as fetchPage, setup } from '@nuxt/test-utils/e2e'
+import { describe, expect, it } from 'vitest'
+
+const rootDir = fileURLToPath(new URL('../..', import.meta.url))
+const buildDir = fileURLToPath(new URL('../../node_modules/.cache/nuxt/.nuxt-e2e', import.meta.url))
+const H1_PATTERN = /<h1(?:\s|>)/g
+const ROBOTS_NOINDEX_PATTERN = /<meta[^>]+name="robots"[^>]+content="noindex, follow"/
+
+function getLinkHref(html: string, rel: string): string | undefined {
+  return html.match(new RegExp(`<link[^>]+rel="${rel}"[^>]+href="([^"]+)"`))?.[1]
+}
+
+function getArticleLinks(html: string): string[] {
+  const links = [...html.matchAll(/href="(\/blogs\/(?!_payload\.json)[^"]+)"/g)]
+    .map(match => match[1])
+    .filter((href): href is string => Boolean(href))
+
+  return [...new Set(links)]
+}
+
+function countH1(html: string): number {
+  return html.match(H1_PATTERN)?.length ?? 0
+}
+
+async function getPage(path: string): Promise<{ response: Response, html: string }> {
+  const response = await fetchPage(path, {
+    headers: {
+      accept: 'text/html',
+    },
+  })
+  return {
+    response,
+    html: await response.text(),
+  }
+}
+
+describe('SEO HTTP and server rendering', async () => {
+  await setup({
+    rootDir,
+    buildDir,
+    browser: false,
+    setupTimeout: 240_000,
+    nuxtConfig: {
+      nitro: {
+        preset: 'node-server',
+      },
+    },
+  })
+
+  it('returns a real 404 for every unknown dynamic route', async () => {
+    const paths = [
+      '/route-inconnue-test-seo',
+      '/blogs/article-inconnu-test-seo',
+      '/categories/categorie-inconnue-test-seo',
+      '/tags/tag-inconnu-test-seo',
+    ]
+
+    for (const path of paths) {
+      const { response, html } = await getPage(path)
+      expect(response.status, path).toBe(404)
+      expect(html, path).toContain('noindex')
+    }
+  })
+
+  it('returns 404 for malformed and out-of-range pagination', async () => {
+    const paths = [
+      '/blogs?page=0',
+      '/blogs?page=1.5',
+      '/blogs?page=999',
+      '/categories/craft?page=999',
+      '/tags/craft?page=999',
+    ]
+
+    for (const path of paths) {
+      const { response } = await getPage(path)
+      expect(response.status, path).toBe(404)
+    }
+  })
+
+  it('serves page 2 with distinct content and a self-referencing canonical', async () => {
+    const page1 = await getPage('/blogs')
+    const page2 = await getPage('/blogs?page=2')
+    const page1Links = getArticleLinks(page1.html)
+    const page2Links = getArticleLinks(page2.html)
+
+    expect(page1.response.status).toBe(200)
+    expect(page2.response.status).toBe(200)
+    expect(page1Links).toHaveLength(12)
+    expect(page2Links).toHaveLength(12)
+    expect(page2Links).not.toEqual(page1Links)
+    expect(page2Links.some(link => page1Links.includes(link))).toBe(false)
+    expect(getLinkHref(page2.html, 'canonical')).toBe('https://blog.hoppr.tech/blogs?page=2')
+    expect(getLinkHref(page2.html, 'prev')).toBe('/blogs')
+    expect(getLinkHref(page2.html, 'next')).toBe('/blogs?page=3')
+  })
+
+  it('noindexes search results and canonicalizes them to the archive', async () => {
+    const { response, html } = await getPage('/blogs?search=Kotest')
+
+    expect(response.status).toBe(200)
+    expect(html).toMatch(ROBOTS_NOINDEX_PATTERN)
+    expect(getLinkHref(html, 'canonical')).toBe('https://blog.hoppr.tech/blogs')
+    expect(getArticleLinks(html)).toContain(
+      '/blogs/2026-07-28-property-based-testing-comment-bien-choisir-ses-proprietes-avec-kotest',
+    )
+  })
+
+  it('renders tag and category hub links in the initial HTML with one H1', async () => {
+    const tags = await getPage('/tags')
+    const categories = await getPage('/categories')
+
+    expect(tags.response.status).toBe(200)
+    expect(categories.response.status).toBe(200)
+    expect(tags.html).toContain('href="/tags/craft"')
+    expect(categories.html).toContain('href="/categories/craft"')
+    expect(countH1(tags.html)).toBe(1)
+    expect(countH1(categories.html)).toBe(1)
+  })
+
+  it('serves paginated tag and category archives with their own canonicals', async () => {
+    const tagPage = await getPage('/tags/craft?page=2')
+    const categoryPage = await getPage('/categories/craft?page=2')
+
+    expect(tagPage.response.status).toBe(200)
+    expect(categoryPage.response.status).toBe(200)
+    expect(getLinkHref(tagPage.html, 'canonical'))
+      .toBe('https://blog.hoppr.tech/tags/craft?page=2')
+    expect(getLinkHref(categoryPage.html, 'canonical'))
+      .toBe('https://blog.hoppr.tech/categories/craft?page=2')
+  })
+})

--- a/tests/e2e/seo-rendering.e2e.ts
+++ b/tests/e2e/seo-rendering.e2e.ts
@@ -1,3 +1,5 @@
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { fetch as fetchPage, setup } from '@nuxt/test-utils/e2e'
 import { describe, expect, it } from 'vitest'
@@ -6,6 +8,7 @@ const rootDir = fileURLToPath(new URL('../..', import.meta.url))
 const buildDir = fileURLToPath(new URL('../../node_modules/.cache/nuxt/.nuxt-e2e', import.meta.url))
 const H1_PATTERN = /<h1(?:\s|>)/g
 const ROBOTS_NOINDEX_PATTERN = /<meta[^>]+name="robots"[^>]+content="noindex, follow"/
+const contentDir = fileURLToPath(new URL('../../content/blogs', import.meta.url))
 
 function getLinkHref(html: string, rel: string): string | undefined {
   return html.match(new RegExp(`<link[^>]+rel="${rel}"[^>]+href="([^"]+)"`))?.[1]
@@ -21,6 +24,49 @@ function getArticleLinks(html: string): string[] {
 
 function countH1(html: string): number {
   return html.match(H1_PATTERN)?.length ?? 0
+}
+
+function getMetaContent(html: string, name: string): string | undefined {
+  const marker = `<meta name="${name}" content="`
+  const contentStart = html.indexOf(marker)
+  if (contentStart === -1)
+    return undefined
+
+  const valueStart = contentStart + marker.length
+  const valueEnd = html.indexOf('">', valueStart)
+  return valueEnd === -1 ? undefined : html.slice(valueStart, valueEnd)
+}
+
+function getFrontmatterValue(markdown: string, key: string): string | undefined {
+  const prefix = `${key}:`
+  return markdown
+    .split('\n')
+    .find(line => line.startsWith(prefix))
+    ?.slice(prefix.length)
+    .trim()
+}
+
+function getExpectedArticleLinks(tag: string): string[] {
+  return readdirSync(contentDir, { withFileTypes: true })
+    .filter(entry => entry.isDirectory())
+    .map((entry) => {
+      const articleFile = join(contentDir, entry.name, 'index.md')
+      if (!existsSync(articleFile))
+        return null
+
+      const markdown = readFileSync(articleFile, 'utf8')
+      const date = getFrontmatterValue(markdown, 'date')
+      const tags = getFrontmatterValue(markdown, 'tags')?.slice(1, -1) ?? ''
+      const published = getFrontmatterValue(markdown, 'published') === 'true'
+
+      if (!published || !date || !tags.split(',').some(value => value.trim().replaceAll('\'', '') === tag))
+        return null
+
+      return { date, link: `/blogs/${entry.name}` }
+    })
+    .filter((article): article is { date: string, link: string } => article !== null)
+    .sort((left, right) => right.date.localeCompare(left.date))
+    .map(article => article.link)
 }
 
 async function getPage(path: string): Promise<{ response: Response, html: string }> {
@@ -128,5 +174,30 @@ describe('SEO HTTP and server rendering', async () => {
       .toBe('https://blog.hoppr.tech/tags/craft?page=2')
     expect(getLinkHref(categoryPage.html, 'canonical'))
       .toBe('https://blog.hoppr.tech/categories/craft?page=2')
+  })
+
+  it('orders tag and category archives from newest to oldest', async () => {
+    const expectedLinks = getExpectedArticleLinks('craft').slice(0, 12)
+    const tagPage = await getPage('/tags/craft')
+    const categoryPage = await getPage('/categories/craft')
+
+    expect(getArticleLinks(tagPage.html)).toEqual(expectedLinks)
+    expect(getArticleLinks(categoryPage.html)).toEqual(expectedLinks)
+  })
+
+  it('uses dedicated SEO metadata without changing the editorial H1', async () => {
+    const { response, html } = await getPage(
+      '/blogs/2026-06-22-clean-architecture-avec-react-remettre-des-frontieres-dans-un-frontend-qui-grandit',
+    )
+
+    expect(response.status).toBe(200)
+    expect(html).toContain('<title>Clean Architecture React : structurer un frontend | HoppR</title>')
+    expect(getMetaContent(html, 'description')).toBe('Structurez un frontend React avec la Clean Architecture : couches, dépendances et frontières claires pour faire évoluer l’application sans dette.')
+    expect(html).toContain('Clean Architecture avec React : remettre des frontières dans un frontend qui grandit')
+    expect(countH1(html)).toBe(1)
+
+    const fallback = await getPage('/blogs/2026-05-18-react-compiler')
+    expect(fallback.html).toContain('<title>React Compiler | HoppR</title>')
+    expect(getMetaContent(fallback.html, 'description')).toContain('Depuis que React Compiler est passé en version stable')
   })
 })

--- a/tests/seo/test-helpers.ts
+++ b/tests/seo/test-helpers.ts
@@ -36,9 +36,11 @@ export interface HeadConfig {
 }
 
 /**
- * Type for the useHead mock function that accepts a HeadConfig argument.
+ * Type for the useHead mock function. Nuxt accepts both a static config and a
+ * getter so head entries can react to route changes.
  */
-export type UseHeadFn = (config: HeadConfig) => void
+export type HeadConfigInput = HeadConfig | (() => HeadConfig)
+export type UseHeadFn = (config: HeadConfigInput) => void
 
 /**
  * Type for the useRuntimeConfig mock function.
@@ -72,7 +74,8 @@ export function getLastHeadCall(mockUseHead: ReturnType<typeof mock<UseHeadFn>>)
   if (!lastCall) {
     throw new Error('useHead was never called')
   }
-  return lastCall[0]
+  const input = lastCall[0]
+  return typeof input === 'function' ? input() : input
 }
 
 /**

--- a/types/blog.ts
+++ b/types/blog.ts
@@ -1,8 +1,10 @@
 export interface BlogPost {
   notionId: string
   title: string
+  seoTitle?: string
   date: string
   description: string
+  seoDescription?: string
   image: string
   alt: string
   ogImage: string
@@ -21,6 +23,8 @@ export interface PageContent {
   coverImageAlt: string
   tags: string[]
   title: string
+  seoTitle?: string
+  seoDescription?: string
   content: string
   images: { url: string, alt: string }[]
 }

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -49,5 +49,11 @@ export interface NotionPage {
     'Cover Image Alt': {
       rich_text: Array<{ plain_text: string }>
     }
+    'SEO Title'?: {
+      rich_text: Array<{ plain_text: string }>
+    }
+    'SEO Description'?: {
+      rich_text: Array<{ plain_text: string }>
+    }
   }
 }

--- a/utils/pagination.test.ts
+++ b/utils/pagination.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  buildPaginationHeadLinks,
+  buildPaginationUrl,
+  resolvePageNumber,
+} from './pagination'
+
+describe('resolvePageNumber', () => {
+  it('defaults to page 1 when the query parameter is absent', () => {
+    expect(resolvePageNumber(undefined, 4)).toBe(1)
+  })
+
+  it('accepts a positive integer within range', () => {
+    expect(resolvePageNumber('3', 4)).toBe(3)
+  })
+
+  it.each(['', '0', '-1', '1.5', '01', 'NaN'])('rejects malformed page %s', (page) => {
+    expect(resolvePageNumber(page, 4)).toBeNull()
+  })
+
+  it('rejects repeated and out-of-range page parameters', () => {
+    expect(resolvePageNumber(['2', '3'], 4)).toBeNull()
+    expect(resolvePageNumber('5', 4)).toBeNull()
+  })
+
+  it('allows page 1 for an empty result set', () => {
+    expect(resolvePageNumber(undefined, 0)).toBe(1)
+    expect(resolvePageNumber('1', 0)).toBe(1)
+  })
+})
+
+describe('pagination URLs', () => {
+  it('keeps page 1 query-free and preserves additional query parameters', () => {
+    expect(buildPaginationUrl('/blogs', 1)).toBe('/blogs')
+    expect(buildPaginationUrl('/blogs', 1, { search: 'clean architecture' }))
+      .toBe('/blogs?search=clean+architecture')
+  })
+
+  it('builds consistent previous and next head links', () => {
+    expect(buildPaginationHeadLinks('/blogs', 2, 4)).toEqual([
+      { rel: 'prev', href: '/blogs' },
+      { rel: 'next', href: '/blogs?page=3' },
+    ])
+  })
+})

--- a/utils/pagination.ts
+++ b/utils/pagination.ts
@@ -1,0 +1,69 @@
+const POSITIVE_INTEGER = /^[1-9]\d*$/
+
+/**
+ * Resolve a route query value to a valid page within the available range.
+ *
+ * Page 1 remains valid for an empty result set so search pages can render an
+ * explicit "no result" state. Every malformed, repeated, fractional, zero,
+ * negative, or out-of-range value is rejected.
+ */
+export function resolvePageNumber(value: unknown, totalPages: number): number | null {
+  if (value === undefined) {
+    return 1
+  }
+
+  if (typeof value !== 'string' || !POSITIVE_INTEGER.test(value)) {
+    return null
+  }
+
+  const page = Number(value)
+  const lastPage = Math.max(1, totalPages)
+
+  if (!Number.isSafeInteger(page) || page > lastPage) {
+    return null
+  }
+
+  return page
+}
+
+export function buildPaginationUrl(
+  baseUrl: string,
+  page: number,
+  query: Record<string, string> = {},
+): string {
+  const params = new URLSearchParams(query)
+
+  if (page > 1) {
+    params.set('page', String(page))
+  }
+  else {
+    params.delete('page')
+  }
+
+  const queryString = params.toString()
+  return queryString ? `${baseUrl}?${queryString}` : baseUrl
+}
+
+export function buildPaginationHeadLinks(
+  baseUrl: string,
+  currentPage: number,
+  totalPages: number,
+): Array<{ rel: 'prev' | 'next', href: string }> {
+  const links: Array<{ rel: 'prev' | 'next', href: string }> = []
+
+  if (currentPage > 1) {
+    links.push({
+      rel: 'prev',
+      href: buildPaginationUrl(baseUrl, currentPage - 1),
+    })
+  }
+
+  if (currentPage < totalPages) {
+    links.push({
+      rel: 'next',
+      href: buildPaginationUrl(baseUrl, currentPage + 1),
+    })
+  }
+
+  return links
+}

--- a/utils/seoLimits.ts
+++ b/utils/seoLimits.ts
@@ -1,0 +1,2 @@
+export const SEO_TITLE_MAX_LENGTH = 52
+export const SEO_DESCRIPTION_MAX_LENGTH = 160

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,0 +1,16 @@
+import process from 'node:process'
+import { defineConfig } from 'vitest/config'
+
+// Nuxt's production server build is the subject under test. Vitest defaults
+// NODE_ENV to "test", which enables Vite sourcemaps that conflict with the
+// virtual Satori transform emitted by nuxt-og-image.
+process.env.NODE_ENV = 'production'
+
+export default defineConfig({
+  test: {
+    include: ['tests/e2e/**/*.e2e.ts'],
+    fileParallelism: false,
+    hookTimeout: 240_000,
+    testTimeout: 60_000,
+  },
+})


### PR DESCRIPTION
## Why

The production SEO audit identified several issues that could reduce crawl efficiency and search visibility:

- unknown URLs returned soft 404 pages instead of real HTTP 404 responses;
- paginated archives reused the first page canonical and could serve the same prerendered HTML for every query-string page;
- tag and category links depended on client-side rendering;
- archive pages promoted the oldest articles before recent publications;
- article titles and generated descriptions were too long for search results, with descriptions cut abruptly at 200 characters.

This PR fixes the technical indexing blockers and introduces dedicated article SEO fields without changing editorial H1 content or breaking existing articles.

## What changed

### HTTP status and indexation

- Return real 404 responses for unknown routes, missing/unpublished articles, invalid taxonomies, and malformed or out-of-range pagination.
- Render a dedicated error page with `noindex, nofollow`.
- Mark search result URLs as `noindex` and canonicalize them to the blog archive.

### Pagination and server rendering

- Give each paginated blog, tag, and category page a self-referencing canonical.
- Render previous/next pagination links in the server HTML.
- Keep query-string archives runtime-rendered so page 2 cannot reuse page 1 prerendered HTML.
- Render tag and category hub links directly during SSR.
- Keep a single H1 on tag and category hubs.
- Order published blog, tag, and category archives by date descending.

### Dedicated article SEO metadata

- Add optional `seoTitle` and `seoDescription` fields to the Nuxt Content schema and TypeScript models.
- Read the Notion rich-text properties `SEO Title` and `SEO Description`.
- Serialize these values into article frontmatter when they are present.
- Use dedicated values for the document title, meta description, Open Graph metadata, generated social image, and structured-data description.
- Fall back to the existing editorial `title` and `description` for all legacy articles.
- Keep the editorial title unchanged in the article H1.
- Limit `seoTitle` to 52 characters so the rendered title stays within 60 characters after the ` | HoppR` suffix.
- Limit `seoDescription` to 160 characters and reject overlong values before publication.
- Improve the automatic description fallback so it normalizes whitespace and truncates at a word boundary instead of cutting at 200 characters.
- Add dedicated metadata to the Clean Architecture React article as a representative migration.

## How it works

The metadata flow is:

1. Notion `SEO Title` / `SEO Description`
2. Notion page extraction
3. `PageContent` / `BlogPost`
4. generated Markdown frontmatter
5. Nuxt Content
6. article SEO, Open Graph, and JSON-LD rendering

If either Notion property is empty or missing, the current title or description is used automatically.

Archive ordering is applied at the Nuxt Content query level with `date DESC`, before taxonomy filtering and pagination.

## Validation

- 50 targeted unit tests passing.
- 8 Nuxt end-to-end SEO tests passing.
- E2E coverage verifies real HTTP statuses, canonical pagination, distinct page content, SSR taxonomy links, descending archive order, dedicated SEO metadata, unchanged H1 content, and legacy fallbacks.
- Targeted ESLint checks passing.
- `git diff --check` passing.
- Production Nuxt build exercised by the E2E suite.

## Follow-up

Create the optional `SEO Title` and `SEO Description` rich-text properties in the Notion article database and populate them progressively for existing articles. Until then, legacy content continues to use the fallback behavior.
